### PR TITLE
adds e-net model

### DIFF
--- a/src/lib/e-net/index.test.ts
+++ b/src/lib/e-net/index.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, jest, test} from '@jest/globals';
+import {ENetModel} from './index';
+
+jest.setTimeout(30000);
+
+describe('teads:configure test', () => {
+  test('initialize with params', async () => {
+    const impactModel = new ENetModel();
+    await impactModel.configure('test', {
+      net_energy: 0.001,
+    });
+    await expect(
+      impactModel.calculate([
+        {
+          duration: 3600,
+          'data-in': 14.3,
+          'data-out': 1.16,
+          timestamp: '2021-01-01T00:00:00Z',
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        e_net: 0.015460000000000002,
+        duration: 3600,
+        'data-in': 14.3,
+        'data-out': 1.16,
+        timestamp: '2021-01-01T00:00:00Z',
+      },
+    ]);
+  });
+  test('initialize with params', async () => {
+    const impactModel = new ENetModel();
+    await impactModel.configure('test', {
+      net_energy: 0.001,
+    });
+    await expect(
+      impactModel.calculate([
+        {
+          duration: 3600,
+          'data-in': 14.3,
+          'data-out': 1.16,
+          timestamp: '2021-01-01T00:00:00Z',
+        },
+        {
+          duration: 3600,
+          'data-in': 1.3,
+          'data-out': 0.16,
+          timestamp: '2021-01-01T00:00:00Z',
+        },
+        {
+          duration: 3600,
+          'data-in': 145.3,
+          'data-out': 100.16,
+          timestamp: '2021-01-01T00:00:00Z',
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        e_net: 0.015460000000000002,
+        duration: 3600,
+        'data-in': 14.3,
+        'data-out': 1.16,
+        timestamp: '2021-01-01T00:00:00Z',
+      },
+      {
+        e_net: 0.00146,
+        duration: 3600,
+        'data-in': 1.3,
+        'data-out': 0.16,
+        timestamp: '2021-01-01T00:00:00Z',
+      },
+      {
+        e_net: 0.24546,
+        duration: 3600,
+        'data-in': 145.3,
+        'data-out': 100.16,
+        timestamp: '2021-01-01T00:00:00Z',
+      },
+    ]);
+  });
+});

--- a/src/lib/e-net/index.ts
+++ b/src/lib/e-net/index.ts
@@ -1,0 +1,100 @@
+import {IImpactModelInterface} from '../interfaces';
+import {KeyValuePair} from '../../types/boavizta';
+
+export class ENetModel implements IImpactModelInterface {
+  // Defined for compatibility. Not used in thi smodel.
+  authParams: object | undefined;
+  // name of the data source
+  name: string | undefined;
+  // tdp of the chip being measured
+  data_in = 0;
+  net_energy = 0;
+
+  /**
+   * Defined for compatibility. Not used in TEADS.
+   */
+  authenticate(authParams: object): void {
+    this.authParams = authParams;
+  }
+
+  /**
+   *  Configures the TEADS Plugin for IEF
+   *  @param {string} name name of the resource
+   *  @param {Object} staticParams static parameters for the resource
+   *  @param {number} staticParams.tdp Thermal Design Power in Watts
+   *  @param {Interpolation} staticParams.interpolation Interpolation method
+   */
+  async configure(
+    name: string,
+    staticParams: object | undefined = undefined
+  ): Promise<IImpactModelInterface> {
+    this.name = name;
+
+    if (staticParams === undefined) {
+      throw new Error('Required Parameters not provided');
+    }
+
+    if ('net_energy' in staticParams) {
+      this.net_energy = staticParams?.net_energy as number;
+    }
+
+    return this;
+  }
+
+  /**
+   * Calculate the total emissions for a list of observations
+   *
+   * Each Observation require:
+   *  @param {Object[]} observations
+   *  @param {string} observations[].timestamp RFC3339 timestamp string
+   *  @param {number} observations[].mem-util percentage mem usage
+   */
+  async calculate(observations: object | object[] | undefined): Promise<any[]> {
+    if (observations === undefined) {
+      throw new Error('Required Parameters not provided');
+    } else if (!Array.isArray(observations)) {
+      throw new Error('Observations must be an array');
+    }
+    return observations.map((observation: KeyValuePair) => {
+      this.configure(this.name!, observation);
+      observation['e_net'] = this.calculateEnergy(observation);
+      return observation;
+    });
+  }
+
+  /**
+   * Returns model identifier
+   */
+  modelIdentifier(): string {
+    return 'e-net';
+  }
+
+  /**
+   * Calculates the energy consumption for a single observation
+   * requires
+   *
+   * data-in: GB of inbound network data
+   * data-out: GB of outbound network data
+   * timestamp: RFC3339 timestamp string
+   *
+   * multiplies memory used (GB) by a coefficient (wh/GB) and converts to kwh
+   */
+  private calculateEnergy(observation: KeyValuePair) {
+    if (
+      !('data-in' in observation) ||
+      !('data-out' in observation) ||
+      !('timestamp' in observation)
+    ) {
+      throw new Error(
+        'Required Parameters duration,cpu-util,timestamp not provided for observation'
+      );
+    }
+
+    const net_energy = this.net_energy;
+    //    convert cpu usage to percentage
+    const data_in = observation['data-in'];
+    const data_out = observation['data-out'];
+
+    return (data_in + data_out) * net_energy;
+  }
+}

--- a/src/lib/e-net/index.ts
+++ b/src/lib/e-net/index.ts
@@ -1,8 +1,8 @@
-import {IImpactModelInterface} from '../interfaces';
-import {KeyValuePair} from '../../types/boavizta';
+import { IImpactModelInterface } from '../interfaces';
+import { KeyValuePair } from '../../types/boavizta';
 
 export class ENetModel implements IImpactModelInterface {
-  // Defined for compatibility. Not used in thi smodel.
+  // Defined for compatibility. Not used in this model.
   authParams: object | undefined;
   // name of the data source
   name: string | undefined;
@@ -11,18 +11,16 @@ export class ENetModel implements IImpactModelInterface {
   net_energy = 0;
 
   /**
-   * Defined for compatibility. Not used in TEADS.
+   * Defined for compatibility. Not used in this model.
    */
   authenticate(authParams: object): void {
     this.authParams = authParams;
   }
 
   /**
-   *  Configures the TEADS Plugin for IEF
+   *  Configures the e-net Plugin for IEF
    *  @param {string} name name of the resource
    *  @param {Object} staticParams static parameters for the resource
-   *  @param {number} staticParams.tdp Thermal Design Power in Watts
-   *  @param {Interpolation} staticParams.interpolation Interpolation method
    */
   async configure(
     name: string,


### PR DESCRIPTION
Adds `e-net` model as used in e-shoppen case study.

Model expects:

from config:
`net_energy`: a factor to convert network data to energy used. Unit is kwh/GB

from observations:
`data-in`: inbound data in GB
`data-out`: outbound data in GB

returns:
`e-net` : energy used by network data in kh.