### PR TITLE
add sci model (time and factor conversions)

### DIFF
--- a/src/lib/sci/index.test.ts
+++ b/src/lib/sci/index.test.ts
@@ -1,70 +1,76 @@
-import { describe, expect, jest, test } from '@jest/globals';
-import { SciModel } from './index';
+import {describe, expect, jest, test} from '@jest/globals';
+import {SciModel} from './index';
 jest.setTimeout(30000);
 
 describe('ccf:configure test', () => {
+  test('initialize and test', async () => {
+    const model = await new SciModel().configure('name', {
+      time: 'minutes',
+      factor: 1,
+    });
+    expect(model).toBeInstanceOf(SciModel);
+    await expect(
+      model.calculate([
+        {
+          'operational-emissions': 0.02,
+          'embodied-carbon': 5,
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        'operational-emissions': 0.02,
+        'embodied-carbon': 5,
+        sci: 301.2,
+      },
+    ]);
+    await expect(
+      model.calculate([
+        {
+          'operational-emissions': 20,
+          'embodied-carbon': 0.005,
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        'operational-emissions': 20,
+        'embodied-carbon': 0.005,
+        sci: 1200.3,
+      },
+    ]);
+  }),
     test('initialize and test', async () => {
-        const model = await new SciModel().configure('name', { time: 'minutes', factor: 1 });
-        expect(model).toBeInstanceOf(SciModel);
-        await expect(
-            model.calculate([
-                {
-                    'operational-emissions': 0.02,
-                    'embodied-carbon': 5,
-                },
-            ])
-        ).resolves.toStrictEqual([
-            {
-                'operational-emissions': 0.02,
-                'embodied-carbon': 5,
-                'sci': 301.2
-            },
-        ]);
-        await expect(
-            model.calculate([
-                {
-                    'operational-emissions': 20,
-                    'embodied-carbon': 0.005,
-                },
-            ])
-        ).resolves.toStrictEqual([
-            {
-                'operational-emissions': 20,
-                'embodied-carbon': 0.005,
-                'sci': 1200.3
-            },
-        ]);
-    }),
-        test('initialize and test', async () => {
-            const model = await new SciModel().configure('name', { time: 'days', factor: 100 });
-            expect(model).toBeInstanceOf(SciModel);
-            await expect(
-                model.calculate([
-                    {
-                        'operational-emissions': 0.02,
-                        'embodied-carbon': 5,
-                    },
-                ])
-            ).resolves.toStrictEqual([
-                {
-                    'operational-emissions': 0.02,
-                    'embodied-carbon': 5,
-                    'sci': 4337.28
-                },
-            ]);
-            await expect(
-                model.calculate([
-                    {
-                        'operational-emissions': 20,
-                        'embodied-carbon': 0.005,
-                    },
-                ])
-            ).resolves.toStrictEqual([
-                {
-                    'operational-emissions': 20,
-                    'embodied-carbon': 0.005,
-                    'sci': 17284.32
-                },
-            ]);
-        })
+      const model = await new SciModel().configure('name', {
+        time: 'days',
+        factor: 100,
+      });
+      expect(model).toBeInstanceOf(SciModel);
+      await expect(
+        model.calculate([
+          {
+            'operational-emissions': 0.02,
+            'embodied-carbon': 5,
+          },
+        ])
+      ).resolves.toStrictEqual([
+        {
+          'operational-emissions': 0.02,
+          'embodied-carbon': 5,
+          sci: 4337.28,
+        },
+      ]);
+      await expect(
+        model.calculate([
+          {
+            'operational-emissions': 20,
+            'embodied-carbon': 0.005,
+          },
+        ])
+      ).resolves.toStrictEqual([
+        {
+          'operational-emissions': 20,
+          'embodied-carbon': 0.005,
+          sci: 17284.32,
+        },
+      ]);
+    });
 });

--- a/src/lib/sci/index.test.ts
+++ b/src/lib/sci/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { SciModel } from './index';
+jest.setTimeout(30000);
+
+describe('ccf:configure test', () => {
+    test('initialize and test', async () => {
+        const model = await new SciModel().configure('name', { time: 'minutes', factor: 1 });
+        expect(model).toBeInstanceOf(SciModel);
+        await expect(
+            model.calculate([
+                {
+                    'operational-emissions': 0.02,
+                    'embodied-carbon': 5,
+                },
+            ])
+        ).resolves.toStrictEqual([
+            {
+                'operational-emissions': 0.02,
+                'embodied-carbon': 5,
+                'sci': 301.2
+            },
+        ]);
+        await expect(
+            model.calculate([
+                {
+                    'operational-emissions': 20,
+                    'embodied-carbon': 0.005,
+                },
+            ])
+        ).resolves.toStrictEqual([
+            {
+                'operational-emissions': 20,
+                'embodied-carbon': 0.005,
+                'sci': 1200.3
+            },
+        ]);
+    }),
+        test('initialize and test', async () => {
+            const model = await new SciModel().configure('name', { time: 'days', factor: 100 });
+            expect(model).toBeInstanceOf(SciModel);
+            await expect(
+                model.calculate([
+                    {
+                        'operational-emissions': 0.02,
+                        'embodied-carbon': 5,
+                    },
+                ])
+            ).resolves.toStrictEqual([
+                {
+                    'operational-emissions': 0.02,
+                    'embodied-carbon': 5,
+                    'sci': 4337.28
+                },
+            ]);
+            await expect(
+                model.calculate([
+                    {
+                        'operational-emissions': 20,
+                        'embodied-carbon': 0.005,
+                    },
+                ])
+            ).resolves.toStrictEqual([
+                {
+                    'operational-emissions': 20,
+                    'embodied-carbon': 0.005,
+                    'sci': 17284.32
+                },
+            ]);
+        })
+});

--- a/src/lib/sci/index.test.ts
+++ b/src/lib/sci/index.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, jest, test} from '@jest/globals';
 import {SciModel} from './index';
 jest.setTimeout(30000);
 
-describe('ccf:configure test', () => {
+describe('sci:configure test', () => {
   test('initialize and test', async () => {
     const model = await new SciModel().configure('name', {
       time: 'minutes',
@@ -12,13 +12,13 @@ describe('ccf:configure test', () => {
     await expect(
       model.calculate([
         {
-          'operational-emissions': 0.02,
+          'operational-carbon': 0.02,
           'embodied-carbon': 5,
         },
       ])
     ).resolves.toStrictEqual([
       {
-        'operational-emissions': 0.02,
+        'operational-carbon': 0.02,
         'embodied-carbon': 5,
         sci: 301.2,
       },
@@ -26,13 +26,13 @@ describe('ccf:configure test', () => {
     await expect(
       model.calculate([
         {
-          'operational-emissions': 20,
+          'operational-carbon': 20,
           'embodied-carbon': 0.005,
         },
       ])
     ).resolves.toStrictEqual([
       {
-        'operational-emissions': 20,
+        'operational-carbon': 20,
         'embodied-carbon': 0.005,
         sci: 1200.3,
       },
@@ -47,13 +47,13 @@ describe('ccf:configure test', () => {
       await expect(
         model.calculate([
           {
-            'operational-emissions': 0.02,
+            'operational-carbon': 0.02,
             'embodied-carbon': 5,
           },
         ])
       ).resolves.toStrictEqual([
         {
-          'operational-emissions': 0.02,
+          'operational-carbon': 0.02,
           'embodied-carbon': 5,
           sci: 4337.28,
         },
@@ -61,13 +61,13 @@ describe('ccf:configure test', () => {
       await expect(
         model.calculate([
           {
-            'operational-emissions': 20,
+            'operational-carbon': 20,
             'embodied-carbon': 0.005,
           },
         ])
       ).resolves.toStrictEqual([
         {
-          'operational-emissions': 20,
+          'operational-carbon': 20,
           'embodied-carbon': 0.005,
           sci: 17284.32,
         },

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -29,25 +29,29 @@ export class SciModel implements IImpactModelInterface {
       const sci_secs = emissions + embodied; // sci in time units of /s
       let sci_timed: number = sci_secs;
 
-      if (this.time == 'second' || this.time == 'seconds' || this.time == '') {
+      if (
+        this.time === 'second' ||
+        this.time === 'seconds' ||
+        this.time === ''
+      ) {
         sci_timed = sci_secs;
       }
-      if (this.time == 'minute' || this.time == 'minutes') {
+      if (this.time === 'minute' || this.time === 'minutes') {
         sci_timed = sci_secs * 60;
       }
-      if (this.time == 'hour' || this.time == 'hours') {
+      if (this.time === 'hour' || this.time === 'hours') {
         sci_timed = sci_secs * 60 * 60;
       }
-      if (this.time == 'day' || this.time == 'days') {
+      if (this.time === 'day' || this.time === 'days') {
         sci_timed = sci_secs * 60 * 60 * 24;
       }
-      if (this.time == 'week' || this.time == 'weeks') {
+      if (this.time === 'week' || this.time === 'weeks') {
         sci_timed = sci_secs * 60 * 60 * 24 * 7;
       }
-      if (this.time == 'month' || this.time == 'months') {
+      if (this.time === 'month' || this.time === 'months') {
         sci_timed = sci_secs * 60 * 60 * 24 * 7 * 4;
       }
-      if (this.time == 'year' || this.time == 'years') {
+      if (this.time === 'year' || this.time === 'years') {
         sci_timed = sci_secs * 60 * 60 * 24 * 365;
       }
 

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -1,86 +1,86 @@
-import { IImpactModelInterface } from '../interfaces';
-import { KeyValuePair } from '../../types/boavizta';
+import {IImpactModelInterface} from '../interfaces';
+import {KeyValuePair} from '../../types/boavizta';
 
 export class SciModel implements IImpactModelInterface {
-    authParams: object | undefined = undefined;
-    staticParams: object | undefined;
-    name: string | undefined;
-    time: string | unknown;
-    factor: number = 1;
+  authParams: object | undefined = undefined;
+  staticParams: object | undefined;
+  name: string | undefined;
+  time: string | unknown;
+  factor = 1;
 
-    authenticate(authParams: object): void {
-        this.authParams = authParams;
+  authenticate(authParams: object): void {
+    this.authParams = authParams;
+  }
+
+  async calculate(observations: object | object[] | undefined): Promise<any[]> {
+    if (!Array.isArray(observations)) {
+      throw new Error('observations should be an array');
+    }
+    observations.map((observation: KeyValuePair) => {
+      if (!('operational-emissions' in observation)) {
+        throw new Error('observation missing `operational-emissions`');
+      }
+      if (!('embodied-carbon' in observation)) {
+        throw new Error('observation missing `embodied-carbon`');
+      }
+
+      const emissions = parseFloat(observation['operational-emissions']);
+      const embodied = parseFloat(observation['embodied-carbon']);
+      const sci_secs = emissions + embodied; // sci in time units of /s
+      let sci_timed: number = sci_secs;
+
+      if (this.time == 'second' || this.time == 'seconds' || this.time == '') {
+        sci_timed = sci_secs;
+      }
+      if (this.time == 'minute' || this.time == 'minutes') {
+        sci_timed = sci_secs * 60;
+      }
+      if (this.time == 'hour' || this.time == 'hours') {
+        sci_timed = sci_secs * 60 * 60;
+      }
+      if (this.time == 'day' || this.time == 'days') {
+        sci_timed = sci_secs * 60 * 60 * 24;
+      }
+      if (this.time == 'week' || this.time == 'weeks') {
+        sci_timed = sci_secs * 60 * 60 * 24 * 7;
+      }
+      if (this.time == 'month' || this.time == 'months') {
+        sci_timed = sci_secs * 60 * 60 * 24 * 7 * 4;
+      }
+      if (this.time == 'year' || this.time == 'years') {
+        sci_timed = sci_secs * 60 * 60 * 24 * 365;
+      }
+
+      const factor = this.factor;
+      observation['sci'] = sci_timed / factor;
+      return observation;
+    });
+
+    return Promise.resolve(observations);
+  }
+
+  async configure(
+    name: string,
+    staticParams: object | undefined
+  ): Promise<IImpactModelInterface> {
+    if (staticParams === undefined) {
+      throw new Error('Required Parameters not provided');
     }
 
-    async calculate(observations: object | object[] | undefined): Promise<any[]> {
-        if (!Array.isArray(observations)) {
-            throw new Error('observations should be an array');
-        }
-        observations.map((observation: KeyValuePair) => {
-            if (!('operational-emissions' in observation)) {
-                throw new Error('observation missing `operational-emissions`');
-            }
-            if (!('embodied-carbon' in observation)) {
-                throw new Error('observation missing `embodied-carbon`');
-            }
+    this.staticParams = staticParams;
+    this.name = name;
 
-            const emissions = parseFloat(observation['operational-emissions']);
-            const embodied = parseFloat(observation['embodied-carbon']);
-            const sci_secs = emissions + embodied; // sci in time units of /s
-            let sci_timed: number = sci_secs;
-
-            if ((this.time == 'second') || (this.time == 'seconds') || (this.time == '')) {
-                sci_timed = sci_secs
-            }
-            if ((this.time == 'minute') || (this.time == 'minutes')) {
-                sci_timed = sci_secs * 60
-            }
-            if ((this.time == 'hour') || (this.time == 'hours')) {
-                sci_timed = sci_secs * 60 * 60
-            }
-            if ((this.time == 'day') || (this.time == 'days')) {
-                sci_timed = sci_secs * 60 * 60 * 24
-            }
-            if ((this.time == 'week') || (this.time == 'weeks')) {
-                sci_timed = sci_secs * 60 * 60 * 24 * 7
-            }
-            if ((this.time == 'month') || (this.time == 'months')) {
-                sci_timed = sci_secs * 60 * 60 * 24 * 7 * 4
-            }
-            if ((this.time == 'year') || (this.time == 'years')) {
-                sci_timed = sci_secs * 60 * 60 * 24 * 365
-            }
-
-            const factor = this.factor;
-            observation['sci'] = sci_timed / factor;
-            return observation;
-        });
-
-        return Promise.resolve(observations);
+    if ('time' in staticParams) {
+      this.time = staticParams?.time;
+    }
+    if ('factor' in staticParams && typeof staticParams.factor === 'number') {
+      this.factor = staticParams?.factor;
     }
 
-    async configure(
-        name: string,
-        staticParams: object | undefined
-    ): Promise<IImpactModelInterface> {
-        if (staticParams === undefined) {
-            throw new Error('Required Parameters not provided');
-        }
+    return this;
+  }
 
-        this.staticParams = staticParams;
-        this.name = name;
-
-        if ('time' in staticParams) {
-            this.time = staticParams?.time;
-        }
-        if (('factor' in staticParams) && typeof (staticParams.factor) == 'number') {
-            this.factor = staticParams?.factor;
-        }
-
-        return this;
-    }
-
-    modelIdentifier(): string {
-        return 'org.gsf.sci';
-    }
+  modelIdentifier(): string {
+    return 'org.gsf.sci';
+  }
 }

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -1,0 +1,86 @@
+import { IImpactModelInterface } from '../interfaces';
+import { KeyValuePair } from '../../types/boavizta';
+
+export class SciModel implements IImpactModelInterface {
+    authParams: object | undefined = undefined;
+    staticParams: object | undefined;
+    name: string | undefined;
+    time: string | unknown;
+    factor: number = 1;
+
+    authenticate(authParams: object): void {
+        this.authParams = authParams;
+    }
+
+    async calculate(observations: object | object[] | undefined): Promise<any[]> {
+        if (!Array.isArray(observations)) {
+            throw new Error('observations should be an array');
+        }
+        observations.map((observation: KeyValuePair) => {
+            if (!('operational-emissions' in observation)) {
+                throw new Error('observation missing `operational-emissions`');
+            }
+            if (!('embodied-carbon' in observation)) {
+                throw new Error('observation missing `embodied-carbon`');
+            }
+
+            const emissions = parseFloat(observation['operational-emissions']);
+            const embodied = parseFloat(observation['embodied-carbon']);
+            const sci_secs = emissions + embodied; // sci in time units of /s
+            let sci_timed: number = sci_secs;
+
+            if ((this.time == 'second') || (this.time == 'seconds') || (this.time == '')) {
+                sci_timed = sci_secs
+            }
+            if ((this.time == 'minute') || (this.time == 'minutes')) {
+                sci_timed = sci_secs * 60
+            }
+            if ((this.time == 'hour') || (this.time == 'hours')) {
+                sci_timed = sci_secs * 60 * 60
+            }
+            if ((this.time == 'day') || (this.time == 'days')) {
+                sci_timed = sci_secs * 60 * 60 * 24
+            }
+            if ((this.time == 'week') || (this.time == 'weeks')) {
+                sci_timed = sci_secs * 60 * 60 * 24 * 7
+            }
+            if ((this.time == 'month') || (this.time == 'months')) {
+                sci_timed = sci_secs * 60 * 60 * 24 * 7 * 4
+            }
+            if ((this.time == 'year') || (this.time == 'years')) {
+                sci_timed = sci_secs * 60 * 60 * 24 * 365
+            }
+
+            const factor = this.factor;
+            observation['sci'] = sci_timed / factor;
+            return observation;
+        });
+
+        return Promise.resolve(observations);
+    }
+
+    async configure(
+        name: string,
+        staticParams: object | undefined
+    ): Promise<IImpactModelInterface> {
+        if (staticParams === undefined) {
+            throw new Error('Required Parameters not provided');
+        }
+
+        this.staticParams = staticParams;
+        this.name = name;
+
+        if ('time' in staticParams) {
+            this.time = staticParams?.time;
+        }
+        if (('factor' in staticParams) && typeof (staticParams.factor) == 'number') {
+            this.factor = staticParams?.factor;
+        }
+
+        return this;
+    }
+
+    modelIdentifier(): string {
+        return 'org.gsf.sci';
+    }
+}

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -17,16 +17,16 @@ export class SciModel implements IImpactModelInterface {
       throw new Error('observations should be an array');
     }
     observations.map((observation: KeyValuePair) => {
-      if (!('operational-emissions' in observation)) {
-        throw new Error('observation missing `operational-emissions`');
+      if (!('operational-carbon' in observation)) {
+        throw new Error('observation missing `operational-carbon`');
       }
       if (!('embodied-carbon' in observation)) {
         throw new Error('observation missing `embodied-carbon`');
       }
 
-      const emissions = parseFloat(observation['operational-emissions']);
+      const operational = parseFloat(observation['operational-carbon']);
       const embodied = parseFloat(observation['embodied-carbon']);
-      const sci_secs = emissions + embodied; // sci in time units of /s
+      const sci_secs = operational + embodied; // sci in time units of /s
       let sci_timed: number = sci_secs;
 
       if (


### PR DESCRIPTION
Adds `sci` model and tests

`sci` takes in the operational emissions and embodied carbon calculated using other models and normalizes to the given `time` unit  and divides by `factor` to convert to functional unit.

Params:
from config:
`time`: string representing the desired time unit ('minutes', 'days'...) - defaults to seconds
`factor`: number, the factor to divide the time norm'd sci value by to convert to functional units

from observations:
`operational-emissions`: the output from sci-o in g/s
`embodied-carbon`: the embodied carbon in g/s

Returns:
`sci`
calculated as `operational-emissions + embodied-carbon / time-factor / f-unit-factor`