### PR TITLE
Fixes naming and unit errors in CCF and Boavizta models

### DIFF
--- a/src/lib/boavizta/index.test.ts
+++ b/src/lib/boavizta/index.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, jest, test} from '@jest/globals';
-import {BoaviztaCloudImpactModel, BoaviztaCpuImpactModel} from './index';
+import { describe, expect, jest, test } from '@jest/globals';
+import { BoaviztaCloudImpactModel, BoaviztaCpuImpactModel } from './index';
 import axios from 'axios';
 import * as PROVIDERS from '../../__mocks__/boavizta/providers.json';
 import * as COUNTRIES from '../../__mocks__/boavizta/countries.json';
@@ -13,9 +13,9 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 mockAxios.get.mockImplementation(url => {
   switch (url) {
     case 'https://api.boavizta.org/v1/cloud/all_providers':
-      return Promise.resolve({data: PROVIDERS});
+      return Promise.resolve({ data: PROVIDERS });
     case 'https://api.boavizta.org/v1/utils/country_code':
-      return Promise.resolve({data: COUNTRIES});
+      return Promise.resolve({ data: COUNTRIES });
     case 'https://api.boavizta.org/v1/cloud/all_instances?provider=aws':
       return Promise.resolve({
         data: INSTANCE_TYPES['aws'],
@@ -29,15 +29,15 @@ mockAxios.post.mockImplementation(url => {
     case 'https://api.boavizta.org/v1/component/cpu?verbose=false&allocation=LINEAR':
       return Promise.resolve({
         data: {
-          gwp: {manufacture: 0.1, use: 1.0, unit: 'kgCO2eq'},
-          pe: {manufacture: 0.1, use: 1.0, unit: 'MJ'},
+          gwp: { manufacture: 0.1, use: 1.0, unit: 'kgCO2eq' },
+          pe: { manufacture: 0.1, use: 1.0, unit: 'MJ' },
         },
       });
     case 'https://api.boavizta.org/v1/cloud/?verbose=false&allocation=LINEAR':
       return Promise.resolve({
         data: {
-          gwp: {manufacture: 0.1, use: 1.0, unit: 'kgCO2eq'},
-          pe: {manufacture: 0.1, use: 1.0, unit: 'MJ'},
+          gwp: { manufacture: 0.1, use: 1.0, unit: 'kgCO2eq' },
+          pe: { manufacture: 0.1, use: 1.0, unit: 'MJ' },
         },
       });
   }
@@ -48,7 +48,7 @@ describe('cpu:configure test', () => {
     const impactModel = new BoaviztaCpuImpactModel();
 
     await expect(
-      impactModel.configure('test', {allocation: 'wrong'})
+      impactModel.configure('test', { allocation: 'wrong' })
     ).rejects.toThrowError();
     expect(impactModel.name).toBe('test');
   });
@@ -68,7 +68,7 @@ describe('cpu:configure test', () => {
     );
     // improper observations will throw a invalid observations error
     await expect(
-      impactModel.calculate([{invalid: 'observation'}])
+      impactModel.calculate([{ invalid: 'observation' }])
     ).rejects.toStrictEqual(
       Error('Invalid Input: Invalid observations parameter')
     );
@@ -92,7 +92,7 @@ describe('cpu:initialize with params', () => {
         {
           timestamp: '2021-01-01T00:00:00Z',
           duration: 3600,
-          'cpu-util': 0.5,
+          'cpu-util': 50,
         },
       ])
     ).resolves.toStrictEqual([
@@ -136,7 +136,7 @@ describe('cloud:initialize with params', () => {
         {
           timestamp: '2021-01-01T00:00:00Z',
           duration: 15,
-          'cpu-util': 0.34,
+          'cpu-util': 34,
         },
       ])
     ).resolves.toStrictEqual([
@@ -164,22 +164,22 @@ describe('cloud:initialize with params', () => {
         {
           timestamp: '2021-01-01T00:00:00Z',
           duration: 15,
-          'cpu-util': 0.34,
+          'cpu-util': 34,
         },
         {
           timestamp: '2021-01-01T00:00:15Z',
           duration: 15,
-          'cpu-util': 0.12,
+          'cpu-util': 12,
         },
         {
           timestamp: '2021-01-01T00:00:30Z',
           duration: 15,
-          'cpu-util': 0.01,
+          'cpu-util': 1,
         },
         {
           timestamp: '2021-01-01T00:00:45Z',
           duration: 15,
-          'cpu-util': 0.78,
+          'cpu-util': 78,
         },
       ])
     ).rejects.toThrowError();
@@ -203,22 +203,22 @@ describe('cloud:initialize with params', () => {
         {
           timestamp: '2021-01-01T00:00:00Z',
           duration: 15,
-          'cpu-util': 0.34,
+          'cpu-util': 34,
         },
         {
           timestamp: '2021-01-01T00:00:15Z',
           duration: 15,
-          'cpu-util': 0.12,
+          'cpu-util': 12,
         },
         {
           timestamp: '2021-01-01T00:00:30Z',
           duration: 15,
-          'cpu-util': 0.01,
+          'cpu-util': 1,
         },
         {
           timestamp: '2021-01-01T00:00:45Z',
           duration: 15,
-          'cpu-util': 0.78,
+          'cpu-util': 78,
         },
       ])
     ).rejects.toStrictEqual(

--- a/src/lib/boavizta/index.test.ts
+++ b/src/lib/boavizta/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, jest, test } from '@jest/globals';
-import { BoaviztaCloudImpactModel, BoaviztaCpuImpactModel } from './index';
+import {describe, expect, jest, test} from '@jest/globals';
+import {BoaviztaCloudImpactModel, BoaviztaCpuImpactModel} from './index';
 import axios from 'axios';
 import * as PROVIDERS from '../../__mocks__/boavizta/providers.json';
 import * as COUNTRIES from '../../__mocks__/boavizta/countries.json';
@@ -13,9 +13,9 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 mockAxios.get.mockImplementation(url => {
   switch (url) {
     case 'https://api.boavizta.org/v1/cloud/all_providers':
-      return Promise.resolve({ data: PROVIDERS });
+      return Promise.resolve({data: PROVIDERS});
     case 'https://api.boavizta.org/v1/utils/country_code':
-      return Promise.resolve({ data: COUNTRIES });
+      return Promise.resolve({data: COUNTRIES});
     case 'https://api.boavizta.org/v1/cloud/all_instances?provider=aws':
       return Promise.resolve({
         data: INSTANCE_TYPES['aws'],
@@ -29,15 +29,15 @@ mockAxios.post.mockImplementation(url => {
     case 'https://api.boavizta.org/v1/component/cpu?verbose=false&allocation=LINEAR':
       return Promise.resolve({
         data: {
-          gwp: { manufacture: 0.1, use: 1.0, unit: 'kgCO2eq' },
-          pe: { manufacture: 0.1, use: 1.0, unit: 'MJ' },
+          gwp: {manufacture: 0.1, use: 1.0, unit: 'kgCO2eq'},
+          pe: {manufacture: 0.1, use: 1.0, unit: 'MJ'},
         },
       });
     case 'https://api.boavizta.org/v1/cloud/?verbose=false&allocation=LINEAR':
       return Promise.resolve({
         data: {
-          gwp: { manufacture: 0.1, use: 1.0, unit: 'kgCO2eq' },
-          pe: { manufacture: 0.1, use: 1.0, unit: 'MJ' },
+          gwp: {manufacture: 0.1, use: 1.0, unit: 'kgCO2eq'},
+          pe: {manufacture: 0.1, use: 1.0, unit: 'MJ'},
         },
       });
   }
@@ -48,7 +48,7 @@ describe('cpu:configure test', () => {
     const impactModel = new BoaviztaCpuImpactModel();
 
     await expect(
-      impactModel.configure('test', { allocation: 'wrong' })
+      impactModel.configure('test', {allocation: 'wrong'})
     ).rejects.toThrowError();
     expect(impactModel.name).toBe('test');
   });
@@ -68,7 +68,7 @@ describe('cpu:configure test', () => {
     );
     // improper observations will throw a invalid observations error
     await expect(
-      impactModel.calculate([{ invalid: 'observation' }])
+      impactModel.calculate([{invalid: 'observation'}])
     ).rejects.toStrictEqual(
       Error('Invalid Input: Invalid observations parameter')
     );

--- a/src/lib/boavizta/index.ts
+++ b/src/lib/boavizta/index.ts
@@ -1,13 +1,13 @@
 import axios from 'axios';
 
-import { IImpactModelInterface } from '../interfaces';
-import { CONFIG } from '../../config';
+import {IImpactModelInterface} from '../interfaces';
+import {CONFIG} from '../../config';
 
-import { BoaviztaInstanceTypes, IBoaviztaUsageSCI } from '../../types/boavizta';
-import { KeyValuePair } from '../../types/common';
+import {BoaviztaInstanceTypes, IBoaviztaUsageSCI} from '../../types/boavizta';
+import {KeyValuePair} from '../../types/common';
 
-const { MODEL_IDS } = CONFIG;
-const { BOAVIZTA_CPU, BOAVIZTA_CLOUD } = MODEL_IDS;
+const {MODEL_IDS} = CONFIG;
+const {BOAVIZTA_CPU, BOAVIZTA_CLOUD} = MODEL_IDS;
 
 abstract class BoaviztaImpactModel implements IImpactModelInterface {
   name: string | undefined;
@@ -114,7 +114,7 @@ abstract class BoaviztaImpactModel implements IImpactModelInterface {
       e = data['pe']['use'] / 3.6;
     }
 
-    return { 'embodied-carbon': m, energy: e };
+    return {'embodied-carbon': m, energy: e};
   }
 
   // converts the usage to the format required by Boavizta API.
@@ -141,7 +141,8 @@ abstract class BoaviztaImpactModel implements IImpactModelInterface {
 
 export class BoaviztaCpuImpactModel
   extends BoaviztaImpactModel
-  implements IImpactModelInterface {
+  implements IImpactModelInterface
+{
   sharedParams: object | undefined = undefined;
   public name: string | undefined;
   public verbose = false;
@@ -203,7 +204,8 @@ export class BoaviztaCpuImpactModel
 
 export class BoaviztaCloudImpactModel
   extends BoaviztaImpactModel
-  implements IImpactModelInterface {
+  implements IImpactModelInterface
+{
   public sharedParams: object | undefined = undefined;
   public instanceTypes: BoaviztaInstanceTypes = {};
   public name: string | undefined;
@@ -221,9 +223,9 @@ export class BoaviztaCloudImpactModel
       if (!countries.includes(location)) {
         throw new Error(
           "Improper configure: Invalid location parameter: '" +
-          location +
-          "'. Valid values are : " +
-          countries.join(', ')
+            location +
+            "'. Valid values are : " +
+            countries.join(', ')
         );
       }
     }
@@ -257,9 +259,9 @@ export class BoaviztaCloudImpactModel
       ) {
         throw new Error(
           "Improper configure: Invalid instance_type parameter: '" +
-          staticParamsCast.instance_type +
-          "'. Valid values are : " +
-          this.instanceTypes[provider].join(', ')
+            staticParamsCast.instance_type +
+            "'. Valid values are : " +
+            this.instanceTypes[provider].join(', ')
         );
       }
     } else {
@@ -276,9 +278,9 @@ export class BoaviztaCloudImpactModel
       if (!supportedProviders.includes(staticParamsCast.provider as string)) {
         throw new Error(
           "Improper configure: Invalid provider parameter: '" +
-          staticParamsCast.provider +
-          "'. Valid values are : " +
-          supportedProviders.join(', ')
+            staticParamsCast.provider +
+            "'. Valid values are : " +
+            supportedProviders.join(', ')
         );
       }
     }
@@ -347,6 +349,6 @@ export class BoaviztaCloudImpactModel
 /**
  * For JSII.
  */
-export { IImpactModelInterface } from '../interfaces';
-export { BoaviztaInstanceTypes, IBoaviztaUsageSCI } from '../../types/boavizta';
-export { KeyValuePair } from '../../types/common';
+export {IImpactModelInterface} from '../interfaces';
+export {BoaviztaInstanceTypes, IBoaviztaUsageSCI} from '../../types/boavizta';
+export {KeyValuePair} from '../../types/common';

--- a/src/lib/boavizta/index.ts
+++ b/src/lib/boavizta/index.ts
@@ -1,13 +1,13 @@
 import axios from 'axios';
 
-import {IImpactModelInterface} from '../interfaces';
-import {CONFIG} from '../../config';
+import { IImpactModelInterface } from '../interfaces';
+import { CONFIG } from '../../config';
 
-import {BoaviztaInstanceTypes, IBoaviztaUsageSCI} from '../../types/boavizta';
-import {KeyValuePair} from '../../types/common';
+import { BoaviztaInstanceTypes, IBoaviztaUsageSCI } from '../../types/boavizta';
+import { KeyValuePair } from '../../types/common';
 
-const {MODEL_IDS} = CONFIG;
-const {BOAVIZTA_CPU, BOAVIZTA_CLOUD} = MODEL_IDS;
+const { MODEL_IDS } = CONFIG;
+const { BOAVIZTA_CPU, BOAVIZTA_CLOUD } = MODEL_IDS;
 
 abstract class BoaviztaImpactModel implements IImpactModelInterface {
   name: string | undefined;
@@ -49,7 +49,7 @@ abstract class BoaviztaImpactModel implements IImpactModelInterface {
     // metric is between 0 and 1, convert to percentage
     let usageInput: KeyValuePair = {
       hours_use_time: duration / 3600.0,
-      time_workload: metric * 100.0,
+      time_workload: metric,
     };
     // convert expected lifespan from seconds to years
     usageInput['years_life_time'] =
@@ -114,7 +114,7 @@ abstract class BoaviztaImpactModel implements IImpactModelInterface {
       e = data['pe']['use'] / 3.6;
     }
 
-    return {'embodied-carbon': m, energy: e};
+    return { 'embodied-carbon': m, energy: e };
   }
 
   // converts the usage to the format required by Boavizta API.
@@ -141,8 +141,7 @@ abstract class BoaviztaImpactModel implements IImpactModelInterface {
 
 export class BoaviztaCpuImpactModel
   extends BoaviztaImpactModel
-  implements IImpactModelInterface
-{
+  implements IImpactModelInterface {
   sharedParams: object | undefined = undefined;
   public name: string | undefined;
   public verbose = false;
@@ -204,8 +203,7 @@ export class BoaviztaCpuImpactModel
 
 export class BoaviztaCloudImpactModel
   extends BoaviztaImpactModel
-  implements IImpactModelInterface
-{
+  implements IImpactModelInterface {
   public sharedParams: object | undefined = undefined;
   public instanceTypes: BoaviztaInstanceTypes = {};
   public name: string | undefined;
@@ -223,9 +221,9 @@ export class BoaviztaCloudImpactModel
       if (!countries.includes(location)) {
         throw new Error(
           "Improper configure: Invalid location parameter: '" +
-            location +
-            "'. Valid values are : " +
-            countries.join(', ')
+          location +
+          "'. Valid values are : " +
+          countries.join(', ')
         );
       }
     }
@@ -259,9 +257,9 @@ export class BoaviztaCloudImpactModel
       ) {
         throw new Error(
           "Improper configure: Invalid instance_type parameter: '" +
-            staticParamsCast.instance_type +
-            "'. Valid values are : " +
-            this.instanceTypes[provider].join(', ')
+          staticParamsCast.instance_type +
+          "'. Valid values are : " +
+          this.instanceTypes[provider].join(', ')
         );
       }
     } else {
@@ -278,9 +276,9 @@ export class BoaviztaCloudImpactModel
       if (!supportedProviders.includes(staticParamsCast.provider as string)) {
         throw new Error(
           "Improper configure: Invalid provider parameter: '" +
-            staticParamsCast.provider +
-            "'. Valid values are : " +
-            supportedProviders.join(', ')
+          staticParamsCast.provider +
+          "'. Valid values are : " +
+          supportedProviders.join(', ')
         );
       }
     }
@@ -349,6 +347,6 @@ export class BoaviztaCloudImpactModel
 /**
  * For JSII.
  */
-export {IImpactModelInterface} from '../interfaces';
-export {BoaviztaInstanceTypes, IBoaviztaUsageSCI} from '../../types/boavizta';
-export {KeyValuePair} from '../../types/common';
+export { IImpactModelInterface } from '../interfaces';
+export { BoaviztaInstanceTypes, IBoaviztaUsageSCI } from '../../types/boavizta';
+export { KeyValuePair } from '../../types/common';

--- a/src/lib/ccf/index.test.ts
+++ b/src/lib/ccf/index.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, jest, test} from '@jest/globals';
-import {CloudCarbonFootprint} from './index';
+import { describe, expect, jest, test } from '@jest/globals';
+import { CloudCarbonFootprint } from './index';
 
 jest.setTimeout(30000);
 
@@ -12,7 +12,7 @@ describe('ccf:configure test', () => {
     });
     await expect(
       impactModel.calculate([
-        {duration: 3600, cpu: 0.5, datetime: '2021-01-01T00:00:00Z'},
+        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
       ])
     ).resolves.toStrictEqual([
       {
@@ -31,17 +31,17 @@ describe('ccf:configure test', () => {
       impactModel.calculate([
         {
           duration: 3600,
-          cpu: 0.1,
+          'cpu-util': 10,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 0.5,
+          'cpu-util': 50,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 1,
+          'cpu-util': 100,
           datetime: '2021-01-01T00:00:00Z',
         },
       ])
@@ -70,17 +70,17 @@ describe('ccf:configure test', () => {
       impactModel.calculate([
         {
           duration: 3600,
-          cpu: 0.1,
+          'cpu-util': 10,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 0.5,
+          'cpu-util': 50,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 1,
+          'cpu-util': 100,
           datetime: '2021-01-01T00:00:00Z',
         },
       ])
@@ -109,17 +109,17 @@ describe('ccf:configure test', () => {
       impactModel.calculate([
         {
           duration: 3600,
-          cpu: 0.1,
+          'cpu-util': 10,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 0.5,
+          'cpu-util': 50,
           datetime: '2021-01-01T00:00:00Z',
         },
         {
           duration: 3600,
-          cpu: 1,
+          'cpu-util': 100,
           datetime: '2021-01-01T00:00:00Z',
         },
       ])
@@ -149,7 +149,7 @@ describe('ccf:configure test', () => {
     ).rejects.toThrowError();
     await expect(
       impactModel.calculate([
-        {duration: 3600, cpu: 0.5, datetime: '2021-01-01T00:00:00Z'},
+        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
       ])
     ).rejects.toThrowError();
   });
@@ -163,7 +163,7 @@ describe('ccf:configure test', () => {
     ).rejects.toThrowError();
     await expect(
       impactModel.calculate([
-        {duration: 3600, cpu: 0.5, datetime: '2021-01-01T00:00:00Z'},
+        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
       ])
     ).rejects.toThrowError();
   });
@@ -178,7 +178,7 @@ describe('ccf:configure test', () => {
     ).resolves.toBeInstanceOf(CloudCarbonFootprint);
     await expect(
       impactModel.calculate([
-        {duration: 3600, cpus: 1, datetime: '2021-01-01T00:00:00Z'},
+        { duration: 3600, cpus: 1, datetime: '2021-01-01T00:00:00Z' },
       ])
     ).rejects.toThrowError();
   });

--- a/src/lib/ccf/index.test.ts
+++ b/src/lib/ccf/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, jest, test } from '@jest/globals';
-import { CloudCarbonFootprint } from './index';
+import {describe, expect, jest, test} from '@jest/globals';
+import {CloudCarbonFootprint} from './index';
 
 jest.setTimeout(30000);
 
@@ -12,7 +12,7 @@ describe('ccf:configure test', () => {
     });
     await expect(
       impactModel.calculate([
-        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
+        {duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z'},
       ])
     ).resolves.toStrictEqual([
       {
@@ -149,7 +149,7 @@ describe('ccf:configure test', () => {
     ).rejects.toThrowError();
     await expect(
       impactModel.calculate([
-        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
+        {duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z'},
       ])
     ).rejects.toThrowError();
   });
@@ -163,7 +163,7 @@ describe('ccf:configure test', () => {
     ).rejects.toThrowError();
     await expect(
       impactModel.calculate([
-        { duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z' },
+        {duration: 3600, 'cpu-util': 50, datetime: '2021-01-01T00:00:00Z'},
       ])
     ).rejects.toThrowError();
   });
@@ -178,7 +178,7 @@ describe('ccf:configure test', () => {
     ).resolves.toBeInstanceOf(CloudCarbonFootprint);
     await expect(
       impactModel.calculate([
-        { duration: 3600, cpus: 1, datetime: '2021-01-01T00:00:00Z' },
+        {duration: 3600, cpus: 1, datetime: '2021-01-01T00:00:00Z'},
       ])
     ).rejects.toThrowError();
   });

--- a/src/lib/ccf/index.ts
+++ b/src/lib/ccf/index.ts
@@ -1,4 +1,4 @@
-import {INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING} from '@cloud-carbon-footprint/aws/dist/lib/AWSInstanceTypes';
+import { INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING } from '@cloud-carbon-footprint/aws/dist/lib/AWSInstanceTypes';
 import Spline from 'typescript-cubic-spline';
 
 import {
@@ -7,7 +7,7 @@ import {
   IImpactModelInterface,
 } from '../interfaces';
 
-import {CONFIG} from '../../config';
+import { CONFIG } from '../../config';
 
 import * as AWS_INSTANCES from './aws-instances.json';
 import * as GCP_INSTANCES from './gcp-instances.json';
@@ -19,10 +19,10 @@ import * as GCP_EMBODIED from './gcp-embodied.json';
 import * as AWS_EMBODIED from './aws-embodied.json';
 import * as AZURE_EMBODIED from './azure-embodied.json';
 
-import {KeyValuePair, Interpolation} from '../../types/common';
+import { KeyValuePair, Interpolation } from '../../types/common';
 
-const {MODEL_IDS} = CONFIG;
-const {CCF} = MODEL_IDS;
+const { MODEL_IDS } = CONFIG;
+const { CCF } = MODEL_IDS;
 
 export class CloudCarbonFootprint implements IImpactModelInterface {
   // Defined for compatibility. Not used in CCF.
@@ -126,7 +126,7 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
    *  @param {Object[]} observations  ISO 8601 datetime string
    *  @param {string} observations[].datetime ISO 8601 datetime string
    *  @param {number} observations[].duration observation duration in seconds
-   *  @param {number} observations[].cpu percentage cpu usage
+   *  @param {number} observations[].cpu-util percentage cpu usage
    */
   async calculate(observations: object | object[] | undefined): Promise<any[]> {
     if (observations === undefined) {
@@ -158,7 +158,7 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
    * requires
    *
    * duration: duration of the observation in seconds
-   * cpu: cpu usage in percentage
+   * cpu-util: cpu usage in percentage
    * datetime: ISO 8601 datetime string
    *
    * Uses a spline method for AWS and linear interpolation for GCP and Azure
@@ -166,7 +166,7 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
   private calculateEnergy(observation: KeyValuePair) {
     if (
       !('duration' in observation) ||
-      !('cpu' in observation) ||
+      !('cpu-util' in observation) ||
       !('datetime' in observation)
     ) {
       throw new Error(
@@ -174,11 +174,8 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
       );
     }
 
-    //    duration is in seconds
     const duration = observation['duration'];
-
-    //    convert cpu usage to percentage
-    const cpu = observation['cpu'] * 100.0;
+    const cpu = observation['cpu-util'];
 
     //  get the wattage for the instance type
     let wattage;
@@ -253,11 +250,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         architecture = this.resolveAwsArchitecture(architecture);
         minWatts +=
           this.computeInstanceUsageByArchitecture['aws'][architecture][
-            'Min Watts'
+          'Min Watts'
           ] ?? 0;
         maxWatts +=
           this.computeInstanceUsageByArchitecture['aws'][architecture][
-            'Max Watts'
+          'Max Watts'
           ] ?? 0;
         count += 1;
       });
@@ -294,11 +291,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         consumption: {
           minWatts:
             this.computeInstanceUsageByArchitecture['gcp'][architecture][
-              'Min Watts'
+            'Min Watts'
             ] * cpus,
           maxWatts:
             this.computeInstanceUsageByArchitecture['gcp'][architecture][
-              'Max Watts'
+            'Max Watts'
             ] * cpus,
         },
         maxvCPUs: parseInt(
@@ -317,11 +314,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         consumption: {
           minWatts:
             this.computeInstanceUsageByArchitecture['azure'][architecture][
-              'Min Watts'
+            'Min Watts'
             ] * cpus,
           maxWatts:
             this.computeInstanceUsageByArchitecture['azure'][architecture][
-              'Max Watts'
+            'Max Watts'
             ] * cpus,
         },
         name: instance['Virtual Machine'],

--- a/src/lib/ccf/index.ts
+++ b/src/lib/ccf/index.ts
@@ -1,4 +1,4 @@
-import { INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING } from '@cloud-carbon-footprint/aws/dist/lib/AWSInstanceTypes';
+import {INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING} from '@cloud-carbon-footprint/aws/dist/lib/AWSInstanceTypes';
 import Spline from 'typescript-cubic-spline';
 
 import {
@@ -7,7 +7,7 @@ import {
   IImpactModelInterface,
 } from '../interfaces';
 
-import { CONFIG } from '../../config';
+import {CONFIG} from '../../config';
 
 import * as AWS_INSTANCES from './aws-instances.json';
 import * as GCP_INSTANCES from './gcp-instances.json';
@@ -19,10 +19,10 @@ import * as GCP_EMBODIED from './gcp-embodied.json';
 import * as AWS_EMBODIED from './aws-embodied.json';
 import * as AZURE_EMBODIED from './azure-embodied.json';
 
-import { KeyValuePair, Interpolation } from '../../types/common';
+import {KeyValuePair, Interpolation} from '../../types/common';
 
-const { MODEL_IDS } = CONFIG;
-const { CCF } = MODEL_IDS;
+const {MODEL_IDS} = CONFIG;
+const {CCF} = MODEL_IDS;
 
 export class CloudCarbonFootprint implements IImpactModelInterface {
   // Defined for compatibility. Not used in CCF.
@@ -250,11 +250,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         architecture = this.resolveAwsArchitecture(architecture);
         minWatts +=
           this.computeInstanceUsageByArchitecture['aws'][architecture][
-          'Min Watts'
+            'Min Watts'
           ] ?? 0;
         maxWatts +=
           this.computeInstanceUsageByArchitecture['aws'][architecture][
-          'Max Watts'
+            'Max Watts'
           ] ?? 0;
         count += 1;
       });
@@ -291,11 +291,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         consumption: {
           minWatts:
             this.computeInstanceUsageByArchitecture['gcp'][architecture][
-            'Min Watts'
+              'Min Watts'
             ] * cpus,
           maxWatts:
             this.computeInstanceUsageByArchitecture['gcp'][architecture][
-            'Max Watts'
+              'Max Watts'
             ] * cpus,
         },
         maxvCPUs: parseInt(
@@ -314,11 +314,11 @@ export class CloudCarbonFootprint implements IImpactModelInterface {
         consumption: {
           minWatts:
             this.computeInstanceUsageByArchitecture['azure'][architecture][
-            'Min Watts'
+              'Min Watts'
             ] * cpus,
           maxWatts:
             this.computeInstanceUsageByArchitecture['azure'][architecture][
-            'Max Watts'
+              'Max Watts'
             ] * cpus,
         },
         name: instance['Virtual Machine'],


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

Updates variable names across models from `cpu` to `cpu-util` for percentage CPU usage arriving from impl.
Removes multiplication by 100 that was previously implemented for converting fractional CPU usage to percentage. We expect `cpu-util` to arrive as a percentage.

Fixes #189
