### PR TITLE
[models]: update use of `duration` and `functional-unit-duration` in `sci` model

### DIFF
--- a/docs/implementations/sci.md
+++ b/docs/implementations/sci.md
@@ -22,11 +22,11 @@ SCI is the sum of the `operational-carbon` (calculated using the `sci-o` model) 
 
 ## IEF Implementation
 
-`sci` takes `operatonal-carbon` and `embodied-carbon` as inputs along with three parameters related to the functional unit: 
+`sci` takes `operational-carbon` and `embodied-carbon` as inputs along with three parameters related to the functional unit: 
 
 - `functional-unit`: a string describing the functional unit to normalize the SCI to. This must match a field provided in the `observations` with an associated value. For example, if `functional-unit` is `"requests"` then there should be a `requests` field in `obserations` with an associated value for the number of requests per `functional-unit-duration`.
 - `functional-unit-time`: a time unit for `functional-unit-duration` as a string. E.g. `s`, `seconds`, `days`, `months`, `y`.
-- `functional-unit-duration`: The length of time, in seconds, that the observation covers. For example, if if the observation period is one day, then `functional-unit-duration` should be `86400` (seconds per day). This is used to ensure that `carbon` is represented in units of C/s at the start of the SCI calculation.
+- `functional-unit-duration`: The length of time, in units of `functional-unit-time` that the `sci` value should be normalized to. We expect this to nearly always be `1`, but for example if you want your `sci` value expressed as gC/user/2yr you could set `functional-unit-duration` to `2`, `functional-unit-time` to `years`, and `functional-unit` to `y`.
 
 In a model pipeline, time is always denominated in `seconds`. It is only in `sci` that other units of time are considered. Therefore, if `functional-unit-time` is `month`, then the sum of `operational-carbon` and `embodied-carbon` is multiplied by the number of seconds in one month.
 
@@ -37,10 +37,10 @@ operational-carbon: 0.02  // operational-carbon per s
 embodied-carbon: 5   // embodied-carbon per s
 functional-unit: requests  // indicate the functional unit is requests
 functional-unit-time: minute  // time unit is minutes
-functional-unit-duration: 1  // observation duration is 1 second
+functional-unit-duration: 1  // time span is 1 functional-unit-time (1 minute)
 requests: 100   // requests per minute
 
-sci-per-s = operational-carbon + embodied-carbon / functional-unit-duration  // (= 5.02)
+sci-per-s = operational-carbon + embodied-carbon / duration  // (= 5.02)
 sci-per-minute = sci-per-s * 60  // (= 301.2)
 sci-per-f-unit = sci-per-duration / 100  // (= 3.012 gC/request)
 ```
@@ -59,6 +59,7 @@ const results = sciModel.calculate([
   {
     operational-carbon: 0.02
     embodied-carbon: 5,
+    duration: 1
     requests: 100,
   }
 ])
@@ -91,5 +92,6 @@ graph:
         - timestamp: 2023-07-06T00:00
           operational-carbon: 0.02
           embodied-carbon: 5
+          duration: 1
           requests: 100
 ```

--- a/src/__mocks__/fs/index.ts
+++ b/src/__mocks__/fs/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {expect} from '@jest/globals';
 
 import * as YAML from 'js-yaml';

--- a/src/__tests__/unit/lib/sci/index.test.ts
+++ b/src/__tests__/unit/lib/sci/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, jest, test } from '@jest/globals';
-import { SciModel } from '../../../../lib/sci/index';
+import {describe, expect, jest, test} from '@jest/globals';
+import {SciModel} from '../../../../lib/sci/index';
 jest.setTimeout(30000);
 
 describe('sci:configure test', () => {

--- a/src/__tests__/unit/lib/sci/index.test.ts
+++ b/src/__tests__/unit/lib/sci/index.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, jest, test} from '@jest/globals';
-import {SciModel} from '../../../../lib/sci/index';
+import { describe, expect, jest, test } from '@jest/globals';
+import { SciModel } from '../../../../lib/sci/index';
 jest.setTimeout(30000);
 
 describe('sci:configure test', () => {
@@ -16,6 +16,7 @@ describe('sci:configure test', () => {
           'operational-carbon': 0.02,
           'embodied-carbon': 5,
           users: 100,
+          duration: 1
         },
       ])
     ).resolves.toStrictEqual([
@@ -23,6 +24,7 @@ describe('sci:configure test', () => {
         'operational-carbon': 0.02,
         'embodied-carbon': 5,
         users: 100,
+        duration: 1,
         sci: 3.012,
       },
     ]);
@@ -32,6 +34,7 @@ describe('sci:configure test', () => {
           'operational-carbon': 20,
           'embodied-carbon': 0.005,
           users: 1000,
+          duration: 1
         },
       ])
     ).resolves.toStrictEqual([
@@ -39,11 +42,12 @@ describe('sci:configure test', () => {
         'operational-carbon': 20,
         'embodied-carbon': 0.005,
         users: 1000,
+        duration: 1,
         sci: 1.2003,
       },
     ]);
   });
-  test('initialize and test', async () => {
+  test('initialize and test: vary observation duration ', async () => {
     const model = await new SciModel().configure('name', {
       'functional-unit-time': 'days',
       'functional-unit': '',
@@ -53,30 +57,60 @@ describe('sci:configure test', () => {
     await expect(
       model.calculate([
         {
-          'operational-carbon': 0.02,
-          'embodied-carbon': 5,
+          'operational-carbon': 0.002,
+          'embodied-carbon': 0.0005,
+          duration: 1
         },
       ])
     ).resolves.toStrictEqual([
       {
-        'operational-carbon': 0.02,
-        'embodied-carbon': 5,
-        sci: 120.47999999999999,
+        'operational-carbon': 0.002,
+        'embodied-carbon': 0.0005,
+        duration: 1,
+        sci: 216,
       },
     ]);
     await expect(
       model.calculate([
         {
-          'operational-carbon': 20,
-          'embodied-carbon': 0.005,
+          'operational-carbon': 0.002,
+          'embodied-carbon': 0.0005,
+          duration: 2
         },
       ])
     ).resolves.toStrictEqual([
       {
-        'operational-carbon': 20,
-        'embodied-carbon': 0.005,
-        sci: 480.12,
+        'operational-carbon': 0.002,
+        'embodied-carbon': 0.0005,
+        duration: 2,
+        sci: 108,
+      },
+    ])
+  }
+  )
+  test('initialize and test: vary fuinctional-unit-duration', async () => {
+    const model = await new SciModel().configure('name', {
+      functional_unit_time: 'days',
+      functional_unit: '',
+      functional_unit_duration: 2,
+    });
+    expect(model).toBeInstanceOf(SciModel);
+    await expect(
+      model.calculate([
+        {
+          'operational-carbon': 0.002,
+          'embodied-carbon': 0.0005,
+          duration: 1
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        'operational-carbon': 0.002,
+        'embodied-carbon': 0.0005,
+        duration: 1,
+        sci: 432,
       },
     ]);
   });
-});
+}
+)

--- a/src/__tests__/unit/lib/sci/index.test.ts
+++ b/src/__tests__/unit/lib/sci/index.test.ts
@@ -89,9 +89,9 @@ describe('sci:configure test', () => {
   });
   test('initialize and test: vary fuinctional-unit-duration', async () => {
     const model = await new SciModel().configure('name', {
-      functional_unit_time: 'days',
-      functional_unit: '',
-      functional_unit_duration: 2,
+      'functional-unit-time': 'days',
+      'functional-unit': '',
+      'functional-unit-duration': 2,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(

--- a/src/__tests__/unit/lib/sci/index.test.ts
+++ b/src/__tests__/unit/lib/sci/index.test.ts
@@ -16,7 +16,7 @@ describe('sci:configure test', () => {
           'operational-carbon': 0.02,
           'embodied-carbon': 5,
           users: 100,
-          duration: 1
+          duration: 1,
         },
       ])
     ).resolves.toStrictEqual([
@@ -34,7 +34,7 @@ describe('sci:configure test', () => {
           'operational-carbon': 20,
           'embodied-carbon': 0.005,
           users: 1000,
-          duration: 1
+          duration: 1,
         },
       ])
     ).resolves.toStrictEqual([
@@ -59,7 +59,7 @@ describe('sci:configure test', () => {
         {
           'operational-carbon': 0.002,
           'embodied-carbon': 0.0005,
-          duration: 1
+          duration: 1,
         },
       ])
     ).resolves.toStrictEqual([
@@ -75,7 +75,7 @@ describe('sci:configure test', () => {
         {
           'operational-carbon': 0.002,
           'embodied-carbon': 0.0005,
-          duration: 2
+          duration: 2,
         },
       ])
     ).resolves.toStrictEqual([
@@ -85,9 +85,8 @@ describe('sci:configure test', () => {
         duration: 2,
         sci: 108,
       },
-    ])
-  }
-  )
+    ]);
+  });
   test('initialize and test: vary fuinctional-unit-duration', async () => {
     const model = await new SciModel().configure('name', {
       functional_unit_time: 'days',
@@ -100,7 +99,7 @@ describe('sci:configure test', () => {
         {
           'operational-carbon': 0.002,
           'embodied-carbon': 0.0005,
-          duration: 1
+          duration: 1,
         },
       ])
     ).resolves.toStrictEqual([
@@ -112,5 +111,4 @@ describe('sci:configure test', () => {
       },
     ]);
   });
-}
-)
+});

--- a/src/__tests__/unit/lib/sci/index.test.ts
+++ b/src/__tests__/unit/lib/sci/index.test.ts
@@ -51,22 +51,22 @@ describe('sci:configure test', () => {
     const model = await new SciModel().configure('name', {
       'functional-unit-time': 'days',
       'functional-unit': '',
-      'functional-unit-duration': 3600,
+      'functional-unit-duration': 1,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(
       model.calculate([
         {
-          'operational-carbon': 0.002,
-          'embodied-carbon': 0.0005,
-          duration: 1,
+          'operational-carbon': 0.2,
+          'embodied-carbon': 0.05,
+          duration: 100,
         },
       ])
     ).resolves.toStrictEqual([
       {
-        'operational-carbon': 0.002,
-        'embodied-carbon': 0.0005,
-        duration: 1,
+        'operational-carbon': 0.2,
+        'embodied-carbon': 0.05,
+        duration: 100,
         sci: 216,
       },
     ]);
@@ -87,7 +87,7 @@ describe('sci:configure test', () => {
       },
     ]);
   });
-  test('initialize and test: vary fuinctional-unit-duration', async () => {
+  test('initialize and test: vary functional-unit-duration', async () => {
     const model = await new SciModel().configure('name', {
       'functional-unit-time': 'days',
       'functional-unit': '',

--- a/src/lib/sci/index.test.ts
+++ b/src/lib/sci/index.test.ts
@@ -1,13 +1,13 @@
 import {describe, expect, jest, test} from '@jest/globals';
-import {SciModel} from '../../../../lib/sci/index';
+import {SciModel} from './index';
 jest.setTimeout(30000);
 
 describe('sci:configure test', () => {
   test('initialize and test', async () => {
     const model = await new SciModel().configure('name', {
-      'functional-unit-time': 'minutes',
-      'functional-unit': 'users',
-      'functional-unit-duration': 1,
+      functional_unit_time: 'minutes',
+      functional_unit: 'users',
+      functional_unit_duration: 1,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(
@@ -49,9 +49,9 @@ describe('sci:configure test', () => {
   });
   test('initialize and test: vary observation duration ', async () => {
     const model = await new SciModel().configure('name', {
-      'functional-unit-time': 'days',
-      'functional-unit': '',
-      'functional-unit-duration': 3600,
+      functional_unit_time: 'days',
+      functional_unit: '',
+      functional_unit_duration: 1,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(

--- a/src/lib/sci/index.test.ts
+++ b/src/lib/sci/index.test.ts
@@ -5,9 +5,9 @@ jest.setTimeout(30000);
 describe('sci:configure test', () => {
   test('initialize and test', async () => {
     const model = await new SciModel().configure('name', {
-      functional_unit_time: 'minutes',
-      functional_unit: 'users',
-      functional_unit_duration: 1,
+      'functional-unit-time': 'minutes',
+      'functional-unit': 'users',
+      'functional-unit-duration': 1,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(
@@ -49,9 +49,9 @@ describe('sci:configure test', () => {
   });
   test('initialize and test: vary observation duration ', async () => {
     const model = await new SciModel().configure('name', {
-      functional_unit_time: 'days',
-      functional_unit: '',
-      functional_unit_duration: 1,
+      'functional-unit-time': 'days',
+      'functional-unit': '',
+      'functional-unit-duration': 1,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(
@@ -89,9 +89,9 @@ describe('sci:configure test', () => {
   });
   test('initialize and test: vary fuinctional-unit-duration', async () => {
     const model = await new SciModel().configure('name', {
-      functional_unit_time: 'days',
-      functional_unit: '',
-      functional_unit_duration: 2,
+      'functional-unit-time': 'days',
+      'functional-unit': '',
+      'functional-unit-duration': 2,
     });
     expect(model).toBeInstanceOf(SciModel);
     await expect(

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -1,11 +1,11 @@
-import {IImpactModelInterface} from '../interfaces';
+import { IImpactModelInterface } from '../interfaces';
 
-import {CONFIG} from '../../config';
+import { CONFIG } from '../../config';
 
-import {KeyValuePair} from '../../types/common';
+import { KeyValuePair } from '../../types/common';
 
-const {MODEL_IDS} = CONFIG;
-const {SCI} = MODEL_IDS;
+const { MODEL_IDS } = CONFIG;
+const { SCI } = MODEL_IDS;
 
 export class SciModel implements IImpactModelInterface {
   authParams: object | undefined = undefined;
@@ -35,15 +35,24 @@ export class SciModel implements IImpactModelInterface {
       const operational = parseFloat(observation['operational-carbon']);
       const embodied = parseFloat(observation['embodied-carbon']);
 
+      /*
+      If `carbon` is in observations, use it. 
+      If not, calculate it from operational and embodied carbon.
+      Divide by observation[duration] to ensure time unit is /s
+      */
       let sci_secs = 0;
       if ('carbon' in observation) {
-        sci_secs = observation['carbon'] / this.functionalUnitDuration;
+        sci_secs = observation['carbon'] / observation['duration'];
       } else {
-        sci_secs = (operational + embodied) / this.functionalUnitDuration; // sci in time units of /s
+        sci_secs = (operational + embodied) / observation['duration']; // sci in time units of /s
       }
 
       let sci_timed: number = sci_secs;
+      let sci_timed_duration = sci_secs;
 
+      /*
+      Convert C to desired time unit
+      */
       if (
         this.time === 's' ||
         this.time === 'second' ||
@@ -89,14 +98,20 @@ export class SciModel implements IImpactModelInterface {
         sci_timed = sci_secs * 60 * 60 * 24 * 365;
       }
 
+      /* 
+      sci currently in whole single units of time - multiply by duration to
+      convert to user-defined span of time.
+      */
+      sci_timed_duration = sci_timed * this.functionalUnitDuration;
+
       const functionalUnit = this.functionalUnit;
 
       if (this.functionalUnit !== 'none') {
         const factor = observation[functionalUnit];
-        observation['sci'] = sci_timed / factor;
+        observation['sci'] = sci_timed_duration / factor;
         return observation;
       } else {
-        observation['sci'] = sci_timed;
+        observation['sci'] = sci_timed_duration;
         return observation;
       }
     });

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -1,11 +1,11 @@
-import { IImpactModelInterface } from '../interfaces';
+import {IImpactModelInterface} from '../interfaces';
 
-import { CONFIG } from '../../config';
+import {CONFIG} from '../../config';
 
-import { KeyValuePair } from '../../types/common';
+import {KeyValuePair} from '../../types/common';
 
-const { MODEL_IDS } = CONFIG;
-const { SCI } = MODEL_IDS;
+const {MODEL_IDS} = CONFIG;
+const {SCI} = MODEL_IDS;
 
 export class SciModel implements IImpactModelInterface {
   authParams: object | undefined = undefined;
@@ -36,7 +36,7 @@ export class SciModel implements IImpactModelInterface {
       const embodied = parseFloat(observation['embodied-carbon']);
 
       /*
-      If `carbon` is in observations, use it. 
+      If `carbon` is in observations, use it.
       If not, calculate it from operational and embodied carbon.
       Divide by observation[duration] to ensure time unit is /s
       */
@@ -98,7 +98,7 @@ export class SciModel implements IImpactModelInterface {
         sci_timed = sci_secs * 60 * 60 * 24 * 365;
       }
 
-      /* 
+      /*
       sci currently in whole single units of time - multiply by duration to
       convert to user-defined span of time.
       */

--- a/src/lib/sci/index.ts
+++ b/src/lib/sci/index.ts
@@ -131,7 +131,7 @@ export class SciModel implements IImpactModelInterface {
     this.name = name;
 
     if ('functional-unit-time' in staticParams) {
-      this.time = staticParams['functional-unit-time'];
+      this.time = staticParams['functional-unit-time'] as number;
     }
     if (
       'functional-unit-duration' in staticParams &&


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

Updates `sci` model to use `duration` from each observation to ensure initial carbon value is expressed in seconds, then uses `functional-unit-duration` to determine the time span for the final `sci` estimate. See Issue #207 for detailed explanation of the problem.

Also updates docs to reflect changes. 

Fixes #207


<!-- Make sure tests and lint pass on CI. -->

